### PR TITLE
Add documentation on installing the generator locally

### DIFF
--- a/generator-playsonapi/README.md
+++ b/generator-playsonapi/README.md
@@ -7,7 +7,17 @@ First, install [Yeoman](http://yeoman.io) and generator-playsonapi using [npm](h
 
 ```bash
 npm install -g yo
+```
+
+To install generator-playsonapi global
+```bash
 npm install -g generator-playsonapi
+```
+
+If you can't or don't want a global install then install the generator only for the current user
+```bash
+cd make-it-in-play/generator-playsonapi
+yarn link
 ```
 
 Then generate your new project:


### PR DESCRIPTION
Not all users have, especially at large enterprises, have the ability to install software as root.  Therefore, it's important to show how to install the generator as the current user.